### PR TITLE
Partially adapt code to current go-ethereum libraries

### DIFF
--- a/p2p/devp2p/common/common.go
+++ b/p2p/devp2p/common/common.go
@@ -13,13 +13,12 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/p2p"
-	"github.com/ethereum/go-ethereum/p2p/discover"
+	discover "github.com/ethereum/go-ethereum/p2p/discv5"
 	"github.com/ethereum/go-ethereum/p2p/protocols"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/ethereum/go-ethereum/swarm"
 	bzzapi "github.com/ethereum/go-ethereum/swarm/api"
 	"github.com/ethereum/go-ethereum/swarm/network"
-	"github.com/ethereum/go-ethereum/swarm/pss"
 )
 
 const (
@@ -104,12 +103,13 @@ func NewSwarmServiceWithProtocol(stack *node.Node, bzzport int, specs []*protoco
 			return nil, err
 		}
 
-		for i, s := range specs {
-			_, err := svc.RegisterPssProtocol(s, protocols[i], &pss.ProtocolParams{true, true})
-			if err != nil {
-				return nil, err
-			}
-		}
+		/*		for i, s := range specs {
+					_, err := svc.RegisterProtocol(s, protocols[i], &pss.ProtocolParams{true, true})
+					if err != nil {
+						return nil, err
+					}
+				}
+		*/
 		return svc, nil
 	}
 }
@@ -213,7 +213,7 @@ func WaitHealthy(ctx context.Context, minbinsize int, rpcs ...*rpc.Client) error
 				return err
 			}
 			Log.Debug("health", "i", i, "addr", common.ToHex(addrs[i]), "id", ids[i], "info", health)
-			if health.KnowNN && health.GotNN && health.Full {
+			if health.KnowNN && health.ConnectNN && health.Saturated {
 				healthycount++
 			}
 		}

--- a/p2p/devp2p/common/common.go
+++ b/p2p/devp2p/common/common.go
@@ -204,8 +204,8 @@ func WaitHealthy(ctx context.Context, minbinsize int, rpcs ...*rpc.Client) error
 		addrs = append(addrs, common.FromHex(bzzaddr))
 	}
 	peerpot := network.NewPeerPotMap(minbinsize, addrs)
+	healthycount := 0
 	for {
-		healthycount := 0
 		for i, r := range rpcs {
 			var health network.Health
 			err := r.Call(&health, "hive_healthy", peerpot)


### PR DESCRIPTION
Not everything fixed yet but now at least the code compiles. It's an start...

Use discv5 instead of discover
Function NewSwarmServiceWithProtocol has commented code, cause I'm not sure how to fix it
In Protocols() make compatible types to compare them ([64]byte)

Signed-off-by: p4u <p4u@dabax.net>